### PR TITLE
chore: remove unavailable pwsh versions

### DIFF
--- a/.github/actions/setup-powershell/action.yml
+++ b/.github/actions/setup-powershell/action.yml
@@ -35,15 +35,8 @@ runs:
     # Verify the installation by checking the `pwsh` command version.
     - run: |
         pwsh --version
-        [[ "$(pwsh --version)" == "PowerShell ${{ inputs.version == '6.0.0' && 'v6.0.0' || inputs.version }}" ]]
+        [[ "$(pwsh --version)" == "PowerShell ${{ inputs.version }}" ]]
       shell: bash
-
-    # Setup old OpenSSL necessary for .NET Core 2.1.
-    - if: ${{ startsWith(inputs.version, '6.') }}
-      shell: bash
-      run: |
-        wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
-        sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
 
     # Verify the installation by using the `pwsh` shell.
     - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Test all Powershell (core) versions on Ubuntu.
-        # See https://github.com/getsentry/sentry-powershell/issues/13 and PR #12 about the disabled versions.
         os: [ubuntu]
         shell: [pwsh]
         version:
           - '7.4.0'
           - '7.3.0'
           - '7.2.0'
-          # - '7.1.0'
-          # - '7.0.0'
-          # - '6.2.0'
-          # - '6.1.0'
-          # - '6.0.0'
         # And test all built-in PowerShell/Windows Powershell versions on latest CI runner images
         include:
           - os: ubuntu
@@ -78,22 +71,7 @@ jobs:
         run: |
           . ./tools/settings.ps1
           Get-Item ./module/Sentry.psd1 | Import-Module
-
-           # Pester doesn't work on PowerShell 6.0 so our testing here is extremely limited.
-           # Also, PowerShell 6.1 doesn't break when there's an error, regardless of the $ErrorActionPreference.
-          if (("${{ matrix.version }}" -eq "6.0.0") -or ("${{ matrix.version }}" -eq "6.1.0"))
-          {
-            if ([Sentry.SentrySdk].GetType().Name -ne 'RuntimeType') { throw "Invalid type on Sentry.SentrySdk" }
-            [Sentry.SentrySdk]::init('https://key@host/1')
-            if (-not [Sentry.SentrySdk]::IsEnabled) { throw "Sentry isn't enabled after init" }
-            [Sentry.SentrySdk]::close()
-            if ([Sentry.SentrySdk]::IsEnabled) { throw "Sentry is still enabled after close" }
-            Write-Host -ForegroundColor Green "All tests successful"
-          }
-          else
-          {
-            $config = New-PesterConfiguration
-            $config.Run.Path = "tests"
-            $config.TestResult.Enabled = $true
-            Invoke-Pester -Configuration $config
-          }
+          $config = New-PesterConfiguration
+          $config.Run.Path = "tests"
+          $config.TestResult.Enabled = $true
+          Invoke-Pester -Configuration $config

--- a/dependencies/download.ps1
+++ b/dependencies/download.ps1
@@ -110,7 +110,6 @@ function Download([string] $dependency, [string] $TFM, [string] $targetTFM = $nu
 
 Download -Dependency 'Sentry' -TFM 'net8.0'
 Download -Dependency 'Sentry' -TFM 'net6.0'
-Download -Dependency 'Sentry' -TFM 'netstandard2.0'
 Download -Dependency 'Sentry' -TFM 'net462'
 
 # You can see the list of dependencies that are actually used in sentry-dotnet/src/Sentry/bin/Debug/net462
@@ -126,14 +125,3 @@ Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Text.Encodings.We
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Text.Json'
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Threading.Tasks.Extensions'
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.ValueTuple'
-
-Download -TFM 'netstandard2.0' -Dependency 'Microsoft.Bcl.AsyncInterfaces'
-Download -TFM 'netstandard2.0' -Dependency 'System.Buffers'
-Download -TFM 'netstandard2.0' -Dependency 'System.Collections.Immutable'
-Download -TFM 'netstandard2.0' -Dependency 'System.Memory'
-Download -TFM 'netstandard2.0' -Dependency 'System.Numerics.Vectors'
-Download -TFM 'netstandard2.0' -Dependency 'System.Reflection.Metadata'
-Download -TFM 'netstandard2.0' -Dependency 'System.Runtime.CompilerServices.Unsafe'
-Download -TFM 'netstandard2.0' -Dependency 'System.Text.Encodings.Web'
-Download -TFM 'netstandard2.0' -Dependency 'System.Text.Json' -assemblyVersion '6.0.0.0'
-Download -TFM 'netstandard2.0' -Dependency 'System.Threading.Tasks.Extensions'

--- a/module/assemblies-loader.ps1
+++ b/module/assemblies-loader.ps1
@@ -19,10 +19,6 @@ function GetTFM
     {
         return 'net6.0'
     }
-    elseif ($PSVersionTable.PSVersion -ge '6.0')
-    {
-        return 'netstandard2.0'
-    }
     else
     {
         return 'net462'


### PR DESCRIPTION
Some PowerShell versions turned out to be a problem to run, with dependency conflicts being the main reason. Since these are already out of support, it should be OK to stick to Powershell 7.2+ and Windows Powershell 5.1

See also #13 for followup to improve compatibility on the new PowerShell versions (7.2+)

#skip-changelog
