### PR TITLE
new sample dsn and readme

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,12 @@
+From the root of the repository, run the following commands:
+
+To run the sample make sure you download the dependencies.
+
+```sh
+pwsh ./dependencies/download.ps1
+```
+
+Then you can run the sample, for example:
+```sh
+pwsh ./samples/locate-city.ps1 Toronto
+```

--- a/samples/locate-city.ps1
+++ b/samples/locate-city.ps1
@@ -20,7 +20,7 @@ Import-Module $PSScriptRoot/../modules/Sentry/Sentry.psd1
 
 # Start the Sentry client.
 Start-Sentry -Debug {
-    $_.Dsn = 'https://eb18e953812b41c3aeb042e666fd3b5c@o447951.ingest.sentry.io/5428537'
+    $_.Dsn = 'https://997874440feaba4ecc65c1e25df7912b@o447951.ingest.us.sentry.io/4508073336176640'
     $_.TracesSampleRate = 1.0
 }
 


### PR DESCRIPTION
Took me a second to understand I had to download some deps first.
And that script must be invoked from the root of the repo (fails if called from `samples`).

Since we don't have a contributing.md yet, just adding instructions as a readme on the sample

Also, added a new project in sentry-sdks: https://sentry-sdks.sentry.io/issues/?project=4508073336176640


#skip-changelog