### PR TITLE
fix: windows powershell needs both unsafe 4.5.3 and 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixes
 
-- StackTrace parsing on Windows Powershell 5.1 ([#50](https://github.com/getsentry/sentry-powershell/pull/50))
+- StackTrace parsing on Windows PowerShell 5.1 ([#50](https://github.com/getsentry/sentry-powershell/pull/50))
 - Fix out of bounds context for short scripts ([#58](https://github.com/getsentry/sentry-powershell/pull/58))
+- Windows PowerShell needs both unsafe 4.5.3 and 6.0.0 dll ([#61](https://github.com/getsentry/sentry-powershell/pull/61))
 
 ### Dependencies
 

--- a/dependencies/System.Runtime.CompilerServices.Unsafe.4.properties
+++ b/dependencies/System.Runtime.CompilerServices.Unsafe.4.properties
@@ -1,3 +1,4 @@
+package = System.Runtime.CompilerServices.Unsafe
 version = 4.5.3
 assemblyVersion = 4.0.4.1
 licenseFile = LICENSE.TXT

--- a/dependencies/System.Runtime.CompilerServices.Unsafe.6.properties
+++ b/dependencies/System.Runtime.CompilerServices.Unsafe.6.properties
@@ -1,0 +1,4 @@
+package = System.Runtime.CompilerServices.Unsafe
+version = 6.0.0
+assemblyVersion = 6.0.0.0
+licenseFile = LICENSE.TXT

--- a/dependencies/download.ps1
+++ b/dependencies/download.ps1
@@ -27,6 +27,7 @@ function Download([string] $dependency, [string] $TFM, [string] $targetTFM = $nu
         $assemblyVersion = $props.ContainsKey('assemblyVersion') ? $props.assemblyVersion : "$($props.version).0"
     }
 
+    $package = $props.ContainsKey('package') ? $props.package : $dependency
     $targetLibFile = "$libDir/$targetTFM/$dependency.dll"
     $targetVersionFile = "$libDir/$targetTFM/$dependency.version"
     $targetLicenseFile = "$libDir/$targetTFM/$dependency.license"
@@ -58,7 +59,7 @@ function Download([string] $dependency, [string] $TFM, [string] $targetTFM = $nu
         Remove-Item $targetLicenseFile -Force
     }
 
-    $archiveName = "$($dependency.ToLower()).$($props.version).nupkg"
+    $archiveName = "$($package.ToLower()).$($props.version).nupkg"
     $archiveFile = "$downloadDir/$archiveName"
 
     if (Test-Path $archiveFile)
@@ -67,8 +68,8 @@ function Download([string] $dependency, [string] $TFM, [string] $targetTFM = $nu
     }
     else
     {
-        Write-Output "Downloading $archiveName"
         $sourceUrl = "https://globalcdn.nuget.org/packages/$archiveName"
+        Write-Output "Downloading $sourceUrl"
         Invoke-WebRequest $sourceUrl -OutFile $archiveFile
     }
 
@@ -89,7 +90,7 @@ function Download([string] $dependency, [string] $TFM, [string] $targetTFM = $nu
 
     try
     {
-        extract "lib/$TFM/$dependency.dll" $targetLibFile
+        extract "lib/$TFM/$package.dll" $targetLibFile
         if ($props.ContainsKey('licenseFile'))
         {
             extract $props.licenseFile $targetLicenseFile
@@ -120,7 +121,8 @@ Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Collections.Immut
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Memory'
 Download -TFM 'net46' -TargetTFM 'net462' -Dependency 'System.Numerics.Vectors'
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Reflection.Metadata'
-Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Runtime.CompilerServices.Unsafe'
+Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Runtime.CompilerServices.Unsafe.4'
+Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Runtime.CompilerServices.Unsafe.6'
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Text.Encodings.Web'
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Text.Json'
 Download -TFM 'net461' -TargetTFM 'net462' -Dependency 'System.Threading.Tasks.Extensions'


### PR DESCRIPTION
I've noticed the failure locally when a span ID is serialized, it would omit it in the output. 