### PR TITLE
ci: Fix PowerShell version format in test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,8 @@ jobs:
         if: ${{ matrix.version != '' }}
         run: |
           $config = Get-Content ./tests/test-pwsh-${{matrix.version}}.props | ConvertFrom-StringData
-          "POWERSHELL_VERSION=$($config.version)" | Out-File -FilePath $env:GITHUB_ENV -Append
+          $version = $config.version -replace '^v',''
+          "POWERSHELL_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Setup PowerShell ${{ env.POWERSHELL_VERSION }}
         if: ${{ matrix.version != '' }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,10 +19,10 @@ jobs:
             path: dependencies/Sentry.properties
           - name: PowerShell Test v7.4
             path: tests/test-pwsh-7.4.props
-            pattern: '^7\.4\.\d+$'
+            pattern: '^v7\.4\.\d+$'
           - name: PowerShell Test v7.5
             path: tests/test-pwsh-7.5.props
-            pattern: '^7\.5\.\d+$'
+            pattern: '^v7\.5\.\d+$'
           - name: PowerShell Test latest
             path: tests/test-pwsh-latest.props
     steps:
@@ -32,4 +32,5 @@ jobs:
           path: ${{ matrix.path }}
           pr-strategy: update
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
+          pattern: ${{ matrix.pattern || '' }}
 

--- a/tests/test-pwsh-7.4.props
+++ b/tests/test-pwsh-7.4.props
@@ -1,2 +1,2 @@
-version = 7.4.0
+version = v7.4.0
 repo = https://github.com/PowerShell/PowerShell/

--- a/tests/test-pwsh-7.5.props
+++ b/tests/test-pwsh-7.5.props
@@ -1,2 +1,2 @@
-version = 7.5.0
+version = v7.5.0
 repo = https://github.com/PowerShell/PowerShell/

--- a/tests/test-pwsh-latest.props
+++ b/tests/test-pwsh-latest.props
@@ -1,2 +1,2 @@
-version = 7.5.0
+version = v7.5.0
 repo = https://github.com/PowerShell/PowerShell/


### PR DESCRIPTION
## Summary
- Standardizes PowerShell version format to use `v` prefix in props files to match GitHub release tags
- Adds version normalization in build workflow to strip `v` prefix before passing to setup-powershell action
- Adds pattern parameter to update-deps workflow for version-specific updates

## Problem
The PowerShell version handling had a mismatch between what the update-deps workflow expected (versions with `v` prefix to match GitHub release tags) and what the setup-powershell action needed (clean version numbers without prefix).

## Solution
- Updated all test-pwsh-*.props files to use version format with `v` prefix (e.g., `v7.4.0`)
- Modified [build.yml](.github/workflows/build.yml#L80) to strip the `v` prefix using PowerShell's `-replace` operator
- Updated [update-deps.yml](.github/workflows/update-deps.yml#L35) to pass the pattern parameter for version-specific matching

## Test plan
- [ ] Verify build workflow correctly strips `v` prefix and passes clean version to setup-powershell
- [ ] Verify update-deps workflow can match and update PowerShell versions with the pattern
- [ ] Ensure all test matrix configurations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)