### PR TITLE
ci: Improve update-deps workflow triggers and permissions

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -6,6 +6,15 @@ on:
     - cron: '0 3 * * *'
   # Allow a manual trigger to be able to run the update when there are new dependencies or after a PR merge to resolve CHANGELOG conflicts.
   workflow_dispatch:
+  # And on every PR merge so we get the updated dependencies ASAP, and to make sure the changelog doesn't conflict.
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write      # To modify files and create commits
+  pull-requests: write # To create and update pull requests
+  actions: write       # To cancel previous workflow runs
 
 jobs:
   deps:
@@ -22,7 +31,7 @@ jobs:
             pattern: '^v7\.4\.\d+$'
           - name: PowerShell Test v7.5
             path: tests/test-pwsh-7.5.props
-            pattern: '^v7\.5\.\d+$'
+            pattern: '^7\.5\.\d+$'
           - name: PowerShell Test latest
             path: tests/test-pwsh-latest.props
     steps:


### PR DESCRIPTION
## Summary
- Adds automatic trigger on push to main branch to get dependency updates ASAP after PR merges and avoid changelog conflicts
- Adds explicit permissions for contents (write), pull-requests (write), and actions (write)
- Fixes PowerShell 7.5 version pattern to match actual release tags (7.5.x instead of v7.5.x)

## Why these changes?
The workflow will now run more frequently to keep dependencies current and reduce merge conflicts in the changelog. The permissions are made explicit for security and clarity.

## Test plan
- [ ] Verify workflow triggers on push to main
- [ ] Verify permissions are correctly applied
- [ ] Verify PowerShell 7.5 version pattern matches actual tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)