### PR TITLE
ci: Separate test dependencies into dedicated workflow job

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,6 +26,20 @@ jobs:
         include:
           - name: Dotnet SDK
             path: dependencies/Sentry.properties
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ matrix.path }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
+
+  test-deps:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: PowerShell Test v7.4
             path: tests/test-pwsh-7.4.props
             pattern: '^v7\.4\.\d+$'
@@ -39,7 +53,6 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.path }}
-          pr-strategy: update
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
           pattern: ${{ matrix.pattern || '' }}
-
+          changelog-entry: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@
 - Bump Dotnet SDK from v5.4.0 to v5.12.0 ([#83](https://github.com/getsentry/sentry-powershell/pull/83))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#5120)
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/5.4.0...5.12.0)
-- Bump PowerShell Test v7.4 from v7.4.0 to v7.4.12 ([#99](https://github.com/getsentry/sentry-powershell/pull/99))
-  - [changelog](https://github.com/PowerShell/PowerShell//blob/master/CHANGELOG.md#v7412)
-  - [diff](https://github.com/PowerShell/PowerShell//compare/v7.4.0...v7.4.12)
 
 ## 0.3.0
 


### PR DESCRIPTION
## Summary
- Split the `update-deps` workflow into two separate jobs: `update-deps` (production dependencies) and `test-deps` (PowerShell test versions)
- Configure test dependencies to skip changelog entries using `changelog-entry: false`
- Remove PowerShell v7.4.12 changelog entry since test dependency updates no longer generate changelog entries

## Test plan
- [ ] Verify workflow file syntax is valid
- [ ] Confirm both jobs run independently
- [ ] Ensure production dependency updates still generate changelog entries
- [ ] Verify test dependency updates skip changelog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)