### PR TITLE
fix: Silence CS1701/CS1702 warnings from Add-Type on PowerShell Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Silence CS1701/CS1702 warnings emitted by `Add-Type` when importing the module on PowerShell hosts whose runtime `System.Runtime` version differs from the one `Sentry.dll` was compiled against ([#129](https://github.com/getsentry/sentry-powershell/pull/129))
+
 ## 0.4.0
 
 ### Fixes

--- a/modules/Sentry/Sentry.psm1
+++ b/modules/Sentry/Sentry.psm1
@@ -5,10 +5,16 @@ $moduleInfo = Import-PowerShellDataFile (Join-Path (Split-Path -Parent $MyInvoca
 . "$privateDir/Get-SentryAssembliesDirectory.ps1"
 $sentryDllPath = (Join-Path (Get-SentryAssembliesDirectory) 'Sentry.dll')
 
-# Suppress CS1701/CS1702: Sentry.dll references System.Runtime at a version that differs from
-# the one loaded by the PowerShell host (e.g. pwsh on .NET 10 vs Sentry.dll's net9.0 metadata).
-# The runtime binds successfully; the warnings are noise.
-Add-Type -TypeDefinition (Get-Content "$privateDir/SentryEventProcessor.cs" -Raw) -ReferencedAssemblies $sentryDllPath -CompilerOptions '/nowarn:CS1701;CS1702' -Debug:$false
+$addTypeParams = @{
+    TypeDefinition       = (Get-Content "$privateDir/SentryEventProcessor.cs" -Raw)
+    ReferencedAssemblies = $sentryDllPath
+    Debug                = $false
+}
+# -CompilerOptions is PS Core only; suppress CS1701/CS1702 (harmless binding-redirect noise) when available.
+if ($PSEdition -eq 'Core') {
+    $addTypeParams['CompilerOptions'] = '/nowarn:CS1701;CS1702'
+}
+Add-Type @addTypeParams
 . "$privateDir/SentryEventProcessor.ps1"
 
 Get-ChildItem $publicDir -Filter '*.ps1' | ForEach-Object {

--- a/modules/Sentry/Sentry.psm1
+++ b/modules/Sentry/Sentry.psm1
@@ -5,7 +5,10 @@ $moduleInfo = Import-PowerShellDataFile (Join-Path (Split-Path -Parent $MyInvoca
 . "$privateDir/Get-SentryAssembliesDirectory.ps1"
 $sentryDllPath = (Join-Path (Get-SentryAssembliesDirectory) 'Sentry.dll')
 
-Add-Type -TypeDefinition (Get-Content "$privateDir/SentryEventProcessor.cs" -Raw) -ReferencedAssemblies $sentryDllPath -Debug:$false
+# Suppress CS1701/CS1702: Sentry.dll references System.Runtime at a version that differs from
+# the one loaded by the PowerShell host (e.g. pwsh on .NET 10 vs Sentry.dll's net9.0 metadata).
+# The runtime binds successfully; the warnings are noise.
+Add-Type -TypeDefinition (Get-Content "$privateDir/SentryEventProcessor.cs" -Raw) -ReferencedAssemblies $sentryDllPath -CompilerOptions '/nowarn:CS1701;CS1702' -Debug:$false
 . "$privateDir/SentryEventProcessor.ps1"
 
 Get-ChildItem $publicDir -Filter '*.ps1' | ForEach-Object {


### PR DESCRIPTION
## Summary

The call to `Add-Type` in `Sentry.psm1` emits `CS1701` warnings on PowerShell Core if the host's runtime `System.Runtime` version doesn't match the one `Sentry.dll` was compiled against (e.g. pwsh 7.6 on .NET 10 loading the `net9.0` build of Sentry). The binding succeeds and the module works, but the warnings are noisy and look alarming.

Pass `/nowarn:CS1701;CS1702` via `-CompilerOptions` so the harmless binding-redirect warnings are suppressed while real compile errors still surface.

Verified locally on pwsh 7.6.1: 5 CS1701 warnings before the change, 0 after, and `Invoke-Pester tests/` still passes (65 passed, 3 skipped).

> [!NOTE]
> `-CompilerOptions` doesn't exist on `Add-Type` in Windows PowerShell 5.1 (Desktop edition) — it's PowerShell Core only so we only add CompilerOptions when `$PSEdition -eq 'Core'`

Closes #132. 