### PR TITLE
Add Add-SentryEventProcessor cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 
 - Add `Write-SentryLog` cmdlet, a native PowerShell API for sending structured logs (Sentry Logs) ([#131](https://github.com/getsentry/sentry-powershell/pull/131))
+- Add `Add-SentryEventProcessor` cmdlet for registering a global event processor from a PowerShell script block ([#130](https://github.com/getsentry/sentry-powershell/pull/130))
 
 ## 0.4.0
 

--- a/modules/Sentry/Sentry.psd1
+++ b/modules/Sentry/Sentry.psd1
@@ -33,6 +33,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = @(
         'Add-SentryBreadcrumb',
+        'Add-SentryEventProcessor',
         'Edit-SentryScope',
         'Invoke-WithSentry',
         'Out-Sentry',

--- a/modules/Sentry/Sentry.psm1
+++ b/modules/Sentry/Sentry.psm1
@@ -4,17 +4,24 @@ $moduleInfo = Import-PowerShellDataFile (Join-Path (Split-Path -Parent $MyInvoca
 
 . "$privateDir/Get-SentryAssembliesDirectory.ps1"
 $sentryDllPath = (Join-Path (Get-SentryAssembliesDirectory) 'Sentry.dll')
+# ScriptBlockEventProcessor.cs uses System.Management.Automation.ScriptBlock.
+$automationDllPath = [System.Management.Automation.PSObject].Assembly.Location
 
-$addTypeParams = @{
-    TypeDefinition       = (Get-Content "$privateDir/SentryEventProcessor.cs" -Raw)
-    ReferencedAssemblies = $sentryDllPath
-    Debug                = $false
+function Add-SentryInlineType([string] $sourceFile, [string[]] $extraReferences) {
+    $addTypeParams = @{
+        TypeDefinition       = (Get-Content $sourceFile -Raw)
+        ReferencedAssemblies = @($sentryDllPath) + $extraReferences
+        Debug                = $false
+    }
+    # -CompilerOptions is PS Core only; suppress CS1701/CS1702 (harmless binding-redirect noise) when available.
+    if ($PSEdition -eq 'Core') {
+        $addTypeParams['CompilerOptions'] = '/nowarn:CS1701;CS1702'
+    }
+    Add-Type @addTypeParams
 }
-# -CompilerOptions is PS Core only; suppress CS1701/CS1702 (harmless binding-redirect noise) when available.
-if ($PSEdition -eq 'Core') {
-    $addTypeParams['CompilerOptions'] = '/nowarn:CS1701;CS1702'
-}
-Add-Type @addTypeParams
+
+Add-SentryInlineType "$privateDir/SentryEventProcessor.cs" @()
+Add-SentryInlineType "$privateDir/ScriptBlockEventProcessor.cs" @($automationDllPath)
 . "$privateDir/SentryEventProcessor.ps1"
 
 Get-ChildItem $publicDir -Filter '*.ps1' | ForEach-Object {

--- a/modules/Sentry/private/ScriptBlockEventProcessor.cs
+++ b/modules/Sentry/private/ScriptBlockEventProcessor.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Management.Automation;
+using Sentry;
+using Sentry.Extensibility;
+
+// Wraps a PowerShell ScriptBlock as an ISentryEventProcessor so the public
+// Add-SentryEventProcessor cmdlet can register user-supplied script blocks with
+// the Sentry pipeline. Implementing the interface in C# (rather than asking users
+// to author a PowerShell class deriving from an internal base) keeps the public
+// API a single scriptblock and avoids the `Process` keyword conflict in Windows
+// PowerShell that would otherwise require a Process_ / DoProcess workaround.
+public sealed class ScriptBlockEventProcessor : ISentryEventProcessor
+{
+    private readonly ScriptBlock _scriptBlock;
+    private readonly IDiagnosticLogger _logger;
+
+    public ScriptBlockEventProcessor(ScriptBlock scriptBlock, IDiagnosticLogger logger)
+    {
+        if (scriptBlock == null) throw new ArgumentNullException("scriptBlock");
+        _scriptBlock = scriptBlock;
+        _logger = logger;
+    }
+
+    public SentryEvent Process(SentryEvent @event)
+    {
+        try
+        {
+            var results = _scriptBlock.Invoke(@event);
+            if (results == null || results.Count == 0)
+            {
+                return @event;
+            }
+
+            var last = results[results.Count - 1];
+            if (last == null)
+            {
+                return null;
+            }
+
+            return (last.BaseObject as SentryEvent) ?? @event;
+        }
+        catch (Exception ex)
+        {
+            if (_logger != null)
+            {
+                _logger.Log(
+                    SentryLevel.Warning,
+                    "Event processor scriptblock failed for event {0}: {1}",
+                    ex,
+                    new object[] { @event.EventId, ex.Message });
+            }
+            return @event;
+        }
+    }
+}

--- a/modules/Sentry/private/ScriptBlockEventProcessor.cs
+++ b/modules/Sentry/private/ScriptBlockEventProcessor.cs
@@ -25,12 +25,11 @@ public sealed class ScriptBlockEventProcessor : ISentryEventProcessor
     {
         try
         {
-            // ScriptBlock.Invoke is not annotated and in practice always returns a
-            // Collection<PSObject>, but guard against null defensively and treat it
-            // the same as "no pipeline output" -> leave the event unchanged.
             var results = _scriptBlock.Invoke(@event);
             if (results == null || results.Count == 0)
             {
+                // No pipeline output (empty block, bare `return`, or a defensive null from Invoke).
+                // Treat as no-opinion and keep the event; explicit `return $null` lands below.
                 return @event;
             }
 

--- a/modules/Sentry/private/ScriptBlockEventProcessor.cs
+++ b/modules/Sentry/private/ScriptBlockEventProcessor.cs
@@ -25,6 +25,9 @@ public sealed class ScriptBlockEventProcessor : ISentryEventProcessor
     {
         try
         {
+            // ScriptBlock.Invoke is not annotated and in practice always returns a
+            // Collection<PSObject>, but guard against null defensively and treat it
+            // the same as "no pipeline output" -> leave the event unchanged.
             var results = _scriptBlock.Invoke(@event);
             if (results == null || results.Count == 0)
             {
@@ -34,10 +37,24 @@ public sealed class ScriptBlockEventProcessor : ISentryEventProcessor
             var last = results[results.Count - 1];
             if (last == null)
             {
+                // User's script block explicitly returned $null -> drop the event.
                 return null;
             }
 
-            return (last.BaseObject as SentryEvent) ?? @event;
+            if (last.BaseObject is SentryEvent processed)
+            {
+                return processed;
+            }
+
+            if (_logger != null)
+            {
+                _logger.Log(
+                    SentryLevel.Warning,
+                    "Event processor scriptblock for event {0} returned {1} instead of a SentryEvent; keeping the original event.",
+                    null,
+                    new object[] { @event.EventId, last.BaseObject?.GetType().FullName ?? "null" });
+            }
+            return @event;
         }
         catch (Exception ex)
         {

--- a/modules/Sentry/private/ScriptBlockEventProcessor.cs
+++ b/modules/Sentry/private/ScriptBlockEventProcessor.cs
@@ -41,18 +41,20 @@ public sealed class ScriptBlockEventProcessor : ISentryEventProcessor
                 return null;
             }
 
-            if (last.BaseObject is SentryEvent processed)
+            var processed = last.BaseObject as SentryEvent;
+            if (processed != null)
             {
                 return processed;
             }
 
             if (_logger != null)
             {
+                var returnedTypeName = last.BaseObject != null ? last.BaseObject.GetType().FullName : "null";
                 _logger.Log(
                     SentryLevel.Warning,
                     "Event processor scriptblock for event {0} returned {1} instead of a SentryEvent; keeping the original event.",
                     null,
-                    new object[] { @event.EventId, last.BaseObject?.GetType().FullName ?? "null" });
+                    new object[] { @event.EventId, returnedTypeName });
             }
             return @event;
         }

--- a/modules/Sentry/public/Add-SentryEventProcessor.ps1
+++ b/modules/Sentry/public/Add-SentryEventProcessor.ps1
@@ -1,0 +1,37 @@
+. "$privateDir/Get-CurrentOptions.ps1"
+
+<#
+.SYNOPSIS
+    Registers a global event processor that runs on every event before it is sent to Sentry.
+.DESCRIPTION
+    The script block receives the Sentry event via the automatic variable $_ (matching the
+    convention used by Edit-SentryScope). Return the event to send it, or $null to drop it.
+.EXAMPLE
+    PS> Add-SentryEventProcessor { $_.SetTag('host', $env:COMPUTERNAME); $_ }
+.EXAMPLE
+    PS> Add-SentryEventProcessor {
+            if ($_.Message -match 'secret') { return $null }
+            $_
+        }
+#>
+function Add-SentryEventProcessor {
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [scriptblock] $ScriptBlock
+    )
+
+    $options = Get-CurrentOptions
+    if ($null -eq $options) {
+        throw 'Sentry is not initialized. Call Start-Sentry before adding an event processor.'
+    }
+
+    # Wrap the user's script block in a pipeline so that $_ is bound to the event,
+    # matching Edit-SentryScope's convention.
+    $wrapped = {
+        param([Sentry.SentryEvent] $event_)
+        $event_ | ForEach-Object $ScriptBlock
+    }.GetNewClosure()
+
+    $options.AddEventProcessor(
+        [ScriptBlockEventProcessor]::new($wrapped, $options.DiagnosticLogger))
+}

--- a/modules/Sentry/public/Start-Sentry.ps1
+++ b/modules/Sentry/public/Start-Sentry.ps1
@@ -38,8 +38,8 @@ function Start-Sentry {
             $options | ForEach-Object $EditOptions
         }
 
-        # Respect a logger supplied via EditOptions (e.g. a TestLogger in tests);
-        # otherwise fall back to the project's default DiagnosticLogger.
+        # Allow the logger to be injected/supplied via EditOptions (e.g. a TestLogger).
+        # Use default DiagnosticLogger as a fall back in normal circumstances.
         if ($null -eq $options.DiagnosticLogger) {
             $options.DiagnosticLogger = [DiagnosticLogger]::new($options.DiagnosticLevel)
         }

--- a/modules/Sentry/public/Start-Sentry.ps1
+++ b/modules/Sentry/public/Start-Sentry.ps1
@@ -38,11 +38,15 @@ function Start-Sentry {
             $options | ForEach-Object $EditOptions
         }
 
-        $logger = [DiagnosticLogger]::new($options.DiagnosticLevel)
+        # Respect a logger supplied via EditOptions (e.g. a TestLogger in tests);
+        # otherwise fall back to the project's default DiagnosticLogger.
+        if ($null -eq $options.DiagnosticLogger) {
+            $options.DiagnosticLogger = [DiagnosticLogger]::new($options.DiagnosticLevel)
+        }
 
         # Note: this is currently a no-op if options.debug == false; see https://github.com/getsentry/sentry-dotnet/issues/3212
         # As a workaround, we set the logger as a global variable so that we can reach it in other scripts.
-        $options.DiagnosticLogger = $logger
+        $logger = $options.DiagnosticLogger
         $script:SentryPowerShellDiagnosticLogger = $logger
 
         if ($null -eq $options.Transport) {

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -50,14 +50,31 @@ Describe 'Add-SentryEventProcessor' {
         $events[0].Tags['second'] | Should -Be '2'
     }
 
-    It 'Still captures the event when the script block throws' {
+    It 'Still captures the event and logs a warning when the script block throws' {
         # Silent-failure contract: a throwing processor must not break event capture
-        # or propagate the exception to the caller of Out-Sentry.
+        # or propagate the exception, and the failure must be logged.
+        Stop-Sentry
+        $logger = [TestLogger]::new([Sentry.SentryLevel]::Debug)
+        Start-Sentry {
+            $_.Dsn = 'https://key@127.0.0.1/1'
+            # Debug=true is required for Sentry to retain a custom DiagnosticLogger;
+            # see https://github.com/getsentry/sentry-dotnet/issues/3212
+            $_.Debug = $true
+            $_.DiagnosticLogger = $logger
+            $_.SetBeforeSend([System.Func[Sentry.SentryEvent, Sentry.SentryEvent]] {
+                    param([Sentry.SentryEvent]$e)
+                    $events.Add($e)
+                    return $e
+                })
+            $_.Transport = $transport
+        }
+
         Add-SentryEventProcessor { throw 'boom' }
         { 'msg' | Out-Sentry } | Should -Not -Throw
 
         $events.Count | Should -Be 1
         $events[0].Message.Message | Should -Be 'msg'
+        ($logger.entries | Where-Object { $_ -match 'Event processor scriptblock failed' }).Count | Should -BeGreaterThan 0
     }
 
     It 'Throws when Sentry is not initialized' {

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -1,0 +1,54 @@
+BeforeAll {
+    . "$PSScriptRoot/utils.ps1"
+    $global:SentryPowershellRethrowErrors = $true
+}
+
+AfterAll {
+    $global:SentryPowershellRethrowErrors = $false
+}
+
+Describe 'Add-SentryEventProcessor' {
+    BeforeEach {
+        $events = [System.Collections.Generic.List[Sentry.SentryEvent]]::new();
+        $transport = [RecordingTransport]::new()
+        StartSentryForEventTests ([ref] $events) ([ref] $transport)
+    }
+
+    AfterEach {
+        $events.Clear()
+        Stop-Sentry
+    }
+
+    It 'Mutates events via $_' {
+        Add-SentryEventProcessor { $_.SetTag('custom', 'value'); $_ }
+        'msg' | Out-Sentry
+
+        $events[0].Tags['custom'] | Should -Be 'value'
+    }
+
+    It 'Drops events when the script block returns $null' {
+        Add-SentryEventProcessor {
+            if ($_.Message.Message -match 'drop-me') { return $null }
+            $_
+        }
+        'drop-me please' | Out-Sentry
+        'keep this one' | Out-Sentry
+
+        $events.Count | Should -Be 1
+        $events[0].Message.Message | Should -Be 'keep this one'
+    }
+
+    It 'Chains multiple processors in registration order' {
+        Add-SentryEventProcessor { $_.SetTag('first', '1'); $_ }
+        Add-SentryEventProcessor { $_.SetTag('second', '2'); $_ }
+        'msg' | Out-Sentry
+
+        $events[0].Tags['first'] | Should -Be '1'
+        $events[0].Tags['second'] | Should -Be '2'
+    }
+
+    It 'Throws when Sentry is not initialized' {
+        Stop-Sentry
+        { Add-SentryEventProcessor { $_ } } | Should -Throw '*Sentry is not initialized*'
+    }
+}

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -74,7 +74,9 @@ Describe 'Add-SentryEventProcessor' {
 
         $events.Count | Should -Be 1
         $events[0].Message.Message | Should -Be 'msg'
-        ($logger.entries | Where-Object { $_ -match 'Event processor scriptblock failed' }).Count | Should -BeGreaterThan 0
+        # Use string-join + -Match: in Windows PowerShell 5.1, Where-Object
+        # unwraps a single result to a scalar, breaking .Count.
+        ($logger.entries -join "`n") | Should -Match 'Event processor scriptblock failed'
     }
 
     It 'Throws when Sentry is not initialized' {

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -50,6 +50,16 @@ Describe 'Add-SentryEventProcessor' {
         $events[0].Tags['second'] | Should -Be '2'
     }
 
+    It 'Still captures the event when the script block throws' {
+        # Silent-failure contract: a throwing processor must not break event capture
+        # or propagate the exception to the caller of Out-Sentry.
+        Add-SentryEventProcessor { throw 'boom' }
+        { 'msg' | Out-Sentry } | Should -Not -Throw
+
+        $events.Count | Should -Be 1
+        $events[0].Message.Message | Should -Be 'msg'
+    }
+
     It 'Throws when Sentry is not initialized' {
         Stop-Sentry
         { Add-SentryEventProcessor { $_ } } | Should -Throw '*Sentry is not initialized*'

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -41,6 +41,20 @@ Describe 'Add-SentryEventProcessor' {
         $events[0].Message.Message | Should -Be 'msg'
     }
 
+    It 'Captures the closure independently for each registration' {
+        # Verifies that GetNewClosure() in Add-SentryEventProcessor binds each
+        # wrapper to its own user-supplied $ScriptBlock — i.e. registrations
+        # don't collapse to a single shared reference. (Note: variables that
+        # the user's scriptblock closes over from the caller's scope are still
+        # resolved at invoke time per normal PowerShell scoping rules.)
+        Add-SentryEventProcessor { $_.SetTag('which', 'first'); $_ }
+        Add-SentryEventProcessor { $_.SetTag('also', 'second'); $_ }
+        'msg' | Out-Sentry
+
+        $events[0].Tags['which'] | Should -Be 'first'
+        $events[0].Tags['also'] | Should -Be 'second'
+    }
+
     It 'Chains multiple processors in registration order' {
         Add-SentryEventProcessor { $_.SetTag('first', '1'); $_ }
         Add-SentryEventProcessor { $_.SetTag('second', '2'); $_ }

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -1,10 +1,5 @@
 BeforeAll {
     . "$PSScriptRoot/utils.ps1"
-    $global:SentryPowershellRethrowErrors = $true
-}
-
-AfterAll {
-    $global:SentryPowershellRethrowErrors = $false
 }
 
 Describe 'Add-SentryEventProcessor' {

--- a/tests/add-sentry-event-processor.tests.ps1
+++ b/tests/add-sentry-event-processor.tests.ps1
@@ -33,6 +33,14 @@ Describe 'Add-SentryEventProcessor' {
         $events[0].Message.Message | Should -Be 'keep this one'
     }
 
+    It 'Keeps the original event when the script block returns a non-SentryEvent value' {
+        Add-SentryEventProcessor { 'not an event' }
+        'msg' | Out-Sentry
+
+        $events.Count | Should -Be 1
+        $events[0].Message.Message | Should -Be 'msg'
+    }
+
     It 'Chains multiple processors in registration order' {
         Add-SentryEventProcessor { $_.SetTag('first', '1'); $_ }
         Add-SentryEventProcessor { $_.SetTag('second', '2'); $_ }


### PR DESCRIPTION
Closes #124 

Adds a public `Add-SentryEventProcessor` cmdlet that accepts a PowerShell script block. The block receives the event via `$_` (matching `Edit-SentryScope`) and can either return the event to send it or return `$null` to drop the event:

```powershell
Add-SentryEventProcessor { $_.SetTag('host', $env:COMPUTERNAME); $_ }

Add-SentryEventProcessor {
    if ($_.Message -match 'secret') { return $null }
    $_
}
```

`Sentry.psm1` factors the existing `Add-Type` call into a small `Add-SentryInlineType` helper so the second `Add-Type` for `ScriptBlockEventProcessor.cs` picks up the same `/nowarn` CompilerOptions treatment (from #129) and can pass an extra `System.Management.Automation` reference.

Includes a Pester test suite covering mutation, drop, processor chaining, and the "Sentry not initialized" guard.