### PR TITLE
Honor InAppInclude / InAppExclude for PowerShell stack frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Features
 
+- Honor `InAppInclude` / `InAppExclude` options when classifying PowerShell stack frames. Entries are matched against the PowerShell module name (the directory under a `$env:PSModulePath` entry) with prefix-then-dot semantics, mirroring how the .NET SDK matches namespaces. Regex variants (`AddInAppIncludeRegex` / `AddInAppExcludeRegex`) are also supported. The existing default — module frames are not in-app, script frames are — is preserved for modules not matched by any rule.
 - Add support for .NET 10 / PowerShell 7.6 ([#133](https://github.com/getsentry/sentry-powershell/pull/133))
 - Add `Write-SentryLog` cmdlet, a native PowerShell API for sending structured logs (Sentry Logs) ([#131](https://github.com/getsentry/sentry-powershell/pull/131))
 - Add `Add-SentryEventProcessor` cmdlet for registering a global event processor from a PowerShell script block ([#130](https://github.com/getsentry/sentry-powershell/pull/130))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Features
 
-- Honor `InAppInclude` / `InAppExclude` options when classifying PowerShell stack frames. Entries are matched against the PowerShell module name (the directory under a `$env:PSModulePath` entry) with prefix-then-dot semantics, mirroring how the .NET SDK matches namespaces. Regex variants (`AddInAppIncludeRegex` / `AddInAppExcludeRegex`) are also supported. The existing default — module frames are not in-app, script frames are — is preserved for modules not matched by any rule.
+- Honor `InAppInclude` / `InAppExclude` options when classifying PowerShell stack frames. Entries are matched against the PowerShell module name (the directory under a `$env:PSModulePath` entry) with prefix-then-dot semantics, mirroring how the .NET SDK matches namespaces. Regex variants (`AddInAppIncludeRegex` / `AddInAppExcludeRegex`) are also supported. The existing default — module frames are not in-app, script frames are — is preserved for modules not matched by any rule. ([#135](https://github.com/getsentry/sentry-powershell/pull/135))
 - Add support for .NET 10 / PowerShell 7.6 ([#133](https://github.com/getsentry/sentry-powershell/pull/133))
 - Add `Write-SentryLog` cmdlet, a native PowerShell API for sending structured logs (Sentry Logs) ([#131](https://github.com/getsentry/sentry-powershell/pull/131))
 - Add `Add-SentryEventProcessor` cmdlet for registering a global event processor from a PowerShell script block ([#130](https://github.com/getsentry/sentry-powershell/pull/130))

--- a/modules/Sentry/private/StackTraceProcessor.ps1
+++ b/modules/Sentry/private/StackTraceProcessor.ps1
@@ -48,7 +48,9 @@ class StackTraceProcessor : SentryEventProcessor {
             $regexValue = $type.GetField('_regex', $flags).GetValue($item)
             if (-not [string]::IsNullOrEmpty($stringValue)) {
                 # Prefix match, matching .NET SDK namespace semantics ("Foo" matches "Foo" and "Foo.Bar").
-                if ($module -eq $stringValue -or $module.StartsWith("$stringValue.")) {
+                # Case-insensitive on both halves, consistent with sentry-dotnet and PS module name resolution.
+                # (PowerShell's -eq is already case-insensitive; StartsWith needs it specified explicitly.)
+                if ($module -eq $stringValue -or $module.StartsWith("$stringValue.", [System.StringComparison]::OrdinalIgnoreCase)) {
                     return $true
                 }
             } elseif ($null -ne $regexValue -and $regexValue.IsMatch($module)) {

--- a/modules/Sentry/private/StackTraceProcessor.ps1
+++ b/modules/Sentry/private/StackTraceProcessor.ps1
@@ -6,6 +6,8 @@ class StackTraceProcessor : SentryEventProcessor {
     hidden [Sentry.Extensibility.IDiagnosticLogger] $logger
     hidden [string[]] $modulePaths
     hidden [hashtable] $pwshModules = @{}
+    hidden [System.Collections.IEnumerable] $inAppInclude
+    hidden [System.Collections.IEnumerable] $inAppExclude
 
     StackTraceProcessor([Sentry.SentryOptions] $options) {
         $this.logger = $options.DiagnosticLogger
@@ -20,6 +22,55 @@ class StackTraceProcessor : SentryEventProcessor {
             # Unix
             $this.modulePaths = $env:PSModulePath -split ':'
         }
+
+        # The SentryOptions.InAppInclude / InAppExclude lists are internal; read them via reflection.
+        # Entries are Sentry.StringOrRegex (string prefix or compiled regex) per the .NET SDK.
+        $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
+        $includeProp = [Sentry.SentryOptions].GetProperty('InAppInclude', $flags)
+        $excludeProp = [Sentry.SentryOptions].GetProperty('InAppExclude', $flags)
+        if ($null -ne $includeProp) {
+            $this.inAppInclude = $includeProp.GetValue($options)
+        }
+        if ($null -ne $excludeProp) {
+            $this.inAppExclude = $excludeProp.GetValue($options)
+        }
+    }
+
+    hidden static [bool] MatchesAny([System.Collections.IEnumerable] $patterns, [string] $module) {
+        if ($null -eq $patterns -or [string]::IsNullOrEmpty($module)) {
+            return $false
+        }
+        foreach ($item in $patterns) {
+            # StringOrRegex has private _string / _regex fields, exactly one set.
+            $type = $item.GetType()
+            $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
+            $stringValue = $type.GetField('_string', $flags).GetValue($item)
+            $regexValue = $type.GetField('_regex', $flags).GetValue($item)
+            if (-not [string]::IsNullOrEmpty($stringValue)) {
+                # Prefix match, matching .NET SDK namespace semantics ("Foo" matches "Foo" and "Foo.Bar").
+                if ($module -eq $stringValue -or $module.StartsWith("$stringValue.")) {
+                    return $true
+                }
+            } elseif ($null -ne $regexValue -and $regexValue.IsMatch($module)) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    hidden [bool] ResolveInApp([Sentry.SentryStackFrame] $sentryFrame) {
+        $module = $sentryFrame.Module
+        # InAppExclude wins, then InAppInclude. Both match against the PowerShell module name we stamped
+        # onto the frame (see SetModule). Falls back to the PS default: user-script frames (no module)
+        # are in-app; module frames are not. This default differs from sentry-dotnet because PS module
+        # frames are almost always third-party.
+        if ([StackTraceProcessor]::MatchesAny($this.inAppExclude, $module)) {
+            return $false
+        }
+        if ([StackTraceProcessor]::MatchesAny($this.inAppInclude, $module)) {
+            return $true
+        }
+        return [string]::IsNullOrEmpty($module)
     }
 
     [Sentry.SentryEvent]DoProcess([Sentry.SentryEvent] $event_) {
@@ -137,7 +188,7 @@ class StackTraceProcessor : SentryEventProcessor {
         foreach ($sentryFrame in $sentryFrames) {
             # Update module info
             $this.SetModule($sentryFrame)
-            $sentryFrame.InApp = [string]::IsNullOrEmpty($sentryFrame.Module)
+            $sentryFrame.InApp = $this.ResolveInApp($sentryFrame)
             $this.SetContextLines($sentryFrame)
         }
 

--- a/modules/Sentry/private/StackTraceProcessor.ps1
+++ b/modules/Sentry/private/StackTraceProcessor.ps1
@@ -6,8 +6,8 @@ class StackTraceProcessor : SentryEventProcessor {
     hidden [Sentry.Extensibility.IDiagnosticLogger] $logger
     hidden [string[]] $modulePaths
     hidden [hashtable] $pwshModules = @{}
-    hidden [object[]] $inAppInclude
-    hidden [object[]] $inAppExclude
+    hidden [System.Collections.IEnumerable] $inAppInclude
+    hidden [System.Collections.IEnumerable] $inAppExclude
 
     StackTraceProcessor([Sentry.SentryOptions] $options) {
         $this.logger = $options.DiagnosticLogger
@@ -23,66 +23,37 @@ class StackTraceProcessor : SentryEventProcessor {
             $this.modulePaths = $env:PSModulePath -split ':'
         }
 
-        # The SentryOptions.InAppInclude / InAppExclude lists are internal; read them via reflection and
-        # normalize each Sentry.StringOrRegex entry into a plain { String; Regex } record up front. This keeps
-        # the reflection (and its failure handling) out of the per-frame hot path, and means a future SDK
-        # rename of these internals degrades gracefully (the option is ignored) instead of crashing capture.
+        # The SentryOptions.InAppInclude / InAppExclude lists are internal; read them via reflection.
+        # Entries are Sentry.StringOrRegex (string prefix or compiled regex) per the .NET SDK.
         $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
         $includeProp = [Sentry.SentryOptions].GetProperty('InAppInclude', $flags)
         $excludeProp = [Sentry.SentryOptions].GetProperty('InAppExclude', $flags)
         if ($null -ne $includeProp) {
-            $this.inAppInclude = $this.ExtractPatterns($includeProp.GetValue($options))
+            $this.inAppInclude = $includeProp.GetValue($options)
         }
         if ($null -ne $excludeProp) {
-            $this.inAppExclude = $this.ExtractPatterns($excludeProp.GetValue($options))
+            $this.inAppExclude = $excludeProp.GetValue($options)
         }
     }
 
-    # Convert a list of Sentry.StringOrRegex into plain [PSCustomObject]@{ String; Regex } records.
-    # StringOrRegex has private _string / _regex fields (exactly one set); reached via reflection.
-    hidden [object[]] ExtractPatterns([System.Collections.IEnumerable] $patterns) {
-        $result = [System.Collections.Generic.List[object]]::new()
-        if ($null -eq $patterns) {
-            return $result.ToArray()
-        }
-        $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
-        foreach ($item in $patterns) {
-            $type = $item.GetType()
-            $stringField = $type.GetField('_string', $flags)
-            $regexField = $type.GetField('_regex', $flags)
-            if ($null -eq $stringField -or $null -eq $regexField) {
-                # sentry-dotnet changed StringOrRegex internals: we can't introspect this entry. Skip it
-                # (so the option simply isn't honored) rather than throwing while capturing an event.
-                if ($null -ne $this.logger) {
-                    $this.logger.Log(
-                        [Sentry.SentryLevel]::Warning,
-                        "Couldn't read an InApp include/exclude pattern via reflection " +
-                        "(Sentry.StringOrRegex internals changed); '$item' will be ignored when classifying frames."
-                    )
-                }
-                continue
-            }
-            $result.Add([PSCustomObject]@{
-                    String = $stringField.GetValue($item)
-                    Regex  = $regexField.GetValue($item)
-                })
-        }
-        return $result.ToArray()
-    }
-
-    hidden static [bool] MatchesAny([object[]] $patterns, [string] $module) {
+    hidden static [bool] MatchesAny([System.Collections.IEnumerable] $patterns, [string] $module) {
         if ($null -eq $patterns -or [string]::IsNullOrEmpty($module)) {
             return $false
         }
         foreach ($item in $patterns) {
-            if (-not [string]::IsNullOrEmpty($item.String)) {
+            # StringOrRegex has private _string / _regex fields, exactly one set.
+            $type = $item.GetType()
+            $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
+            $stringValue = $type.GetField('_string', $flags).GetValue($item)
+            $regexValue = $type.GetField('_regex', $flags).GetValue($item)
+            if (-not [string]::IsNullOrEmpty($stringValue)) {
                 # Prefix match, matching .NET SDK namespace semantics ("Foo" matches "Foo" and "Foo.Bar").
                 # Case-insensitive on both halves, consistent with sentry-dotnet and PS module name resolution.
                 # (PowerShell's -eq is already case-insensitive; StartsWith needs it specified explicitly.)
-                if ($module -eq $item.String -or $module.StartsWith("$($item.String).", [System.StringComparison]::OrdinalIgnoreCase)) {
+                if ($module -eq $stringValue -or $module.StartsWith("$stringValue.", [System.StringComparison]::OrdinalIgnoreCase)) {
                     return $true
                 }
-            } elseif ($null -ne $item.Regex -and $item.Regex.IsMatch($module)) {
+            } elseif ($null -ne $regexValue -and $regexValue.IsMatch($module)) {
                 return $true
             }
         }

--- a/modules/Sentry/private/StackTraceProcessor.ps1
+++ b/modules/Sentry/private/StackTraceProcessor.ps1
@@ -60,8 +60,7 @@ class StackTraceProcessor : SentryEventProcessor {
 
     hidden [bool] ResolveInApp([Sentry.SentryStackFrame] $sentryFrame) {
         $module = $sentryFrame.Module
-        # InAppExclude wins, then InAppInclude. Both match against the PowerShell module name we stamped
-        # onto the frame (see SetModule). Falls back to the PS default: user-script frames (no module)
+        # InAppExclude wins, then InAppInclude. Falls back to the PS default: user-script frames (no module)
         # are in-app; module frames are not. This default differs from sentry-dotnet because PS module
         # frames are almost always third-party.
         if ([StackTraceProcessor]::MatchesAny($this.inAppExclude, $module)) {

--- a/modules/Sentry/private/StackTraceProcessor.ps1
+++ b/modules/Sentry/private/StackTraceProcessor.ps1
@@ -6,8 +6,8 @@ class StackTraceProcessor : SentryEventProcessor {
     hidden [Sentry.Extensibility.IDiagnosticLogger] $logger
     hidden [string[]] $modulePaths
     hidden [hashtable] $pwshModules = @{}
-    hidden [System.Collections.IEnumerable] $inAppInclude
-    hidden [System.Collections.IEnumerable] $inAppExclude
+    hidden [object[]] $inAppInclude
+    hidden [object[]] $inAppExclude
 
     StackTraceProcessor([Sentry.SentryOptions] $options) {
         $this.logger = $options.DiagnosticLogger
@@ -23,37 +23,66 @@ class StackTraceProcessor : SentryEventProcessor {
             $this.modulePaths = $env:PSModulePath -split ':'
         }
 
-        # The SentryOptions.InAppInclude / InAppExclude lists are internal; read them via reflection.
-        # Entries are Sentry.StringOrRegex (string prefix or compiled regex) per the .NET SDK.
+        # The SentryOptions.InAppInclude / InAppExclude lists are internal; read them via reflection and
+        # normalize each Sentry.StringOrRegex entry into a plain { String; Regex } record up front. This keeps
+        # the reflection (and its failure handling) out of the per-frame hot path, and means a future SDK
+        # rename of these internals degrades gracefully (the option is ignored) instead of crashing capture.
         $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
         $includeProp = [Sentry.SentryOptions].GetProperty('InAppInclude', $flags)
         $excludeProp = [Sentry.SentryOptions].GetProperty('InAppExclude', $flags)
         if ($null -ne $includeProp) {
-            $this.inAppInclude = $includeProp.GetValue($options)
+            $this.inAppInclude = $this.ExtractPatterns($includeProp.GetValue($options))
         }
         if ($null -ne $excludeProp) {
-            $this.inAppExclude = $excludeProp.GetValue($options)
+            $this.inAppExclude = $this.ExtractPatterns($excludeProp.GetValue($options))
         }
     }
 
-    hidden static [bool] MatchesAny([System.Collections.IEnumerable] $patterns, [string] $module) {
+    # Convert a list of Sentry.StringOrRegex into plain [PSCustomObject]@{ String; Regex } records.
+    # StringOrRegex has private _string / _regex fields (exactly one set); reached via reflection.
+    hidden [object[]] ExtractPatterns([System.Collections.IEnumerable] $patterns) {
+        $result = [System.Collections.Generic.List[object]]::new()
+        if ($null -eq $patterns) {
+            return $result.ToArray()
+        }
+        $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
+        foreach ($item in $patterns) {
+            $type = $item.GetType()
+            $stringField = $type.GetField('_string', $flags)
+            $regexField = $type.GetField('_regex', $flags)
+            if ($null -eq $stringField -or $null -eq $regexField) {
+                # sentry-dotnet changed StringOrRegex internals: we can't introspect this entry. Skip it
+                # (so the option simply isn't honored) rather than throwing while capturing an event.
+                if ($null -ne $this.logger) {
+                    $this.logger.Log(
+                        [Sentry.SentryLevel]::Warning,
+                        "Couldn't read an InApp include/exclude pattern via reflection " +
+                        "(Sentry.StringOrRegex internals changed); '$item' will be ignored when classifying frames."
+                    )
+                }
+                continue
+            }
+            $result.Add([PSCustomObject]@{
+                    String = $stringField.GetValue($item)
+                    Regex  = $regexField.GetValue($item)
+                })
+        }
+        return $result.ToArray()
+    }
+
+    hidden static [bool] MatchesAny([object[]] $patterns, [string] $module) {
         if ($null -eq $patterns -or [string]::IsNullOrEmpty($module)) {
             return $false
         }
         foreach ($item in $patterns) {
-            # StringOrRegex has private _string / _regex fields, exactly one set.
-            $type = $item.GetType()
-            $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
-            $stringValue = $type.GetField('_string', $flags).GetValue($item)
-            $regexValue = $type.GetField('_regex', $flags).GetValue($item)
-            if (-not [string]::IsNullOrEmpty($stringValue)) {
+            if (-not [string]::IsNullOrEmpty($item.String)) {
                 # Prefix match, matching .NET SDK namespace semantics ("Foo" matches "Foo" and "Foo.Bar").
                 # Case-insensitive on both halves, consistent with sentry-dotnet and PS module name resolution.
                 # (PowerShell's -eq is already case-insensitive; StartsWith needs it specified explicitly.)
-                if ($module -eq $stringValue -or $module.StartsWith("$stringValue.", [System.StringComparison]::OrdinalIgnoreCase)) {
+                if ($module -eq $item.String -or $module.StartsWith("$($item.String).", [System.StringComparison]::OrdinalIgnoreCase)) {
                     return $true
                 }
-            } elseif ($null -ne $regexValue -and $regexValue.IsMatch($module)) {
+            } elseif ($null -ne $item.Regex -and $item.Regex.IsMatch($module)) {
                 return $true
             }
         }

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -30,4 +30,65 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
         $frames[2].AbsolutePath | Should -Be 'C:\dev\sentry-powershell\tests\throwing.ps1'
         $frames[2].LineNumber | Should -Be 17
     }
+
+    Context 'ResolveInApp' {
+        BeforeAll {
+            function New-Frame([string] $module) {
+                $f = [Sentry.SentryStackFrame]::new()
+                $f.Module = $module
+                $f
+            }
+        }
+
+        It 'Defaults user-script frames (no module) to in-app' {
+            $sut = [StackTraceProcessor]::new([Sentry.SentryOptions]::new())
+            $sut.ResolveInApp((New-Frame $null)) | Should -BeTrue
+            $sut.ResolveInApp((New-Frame '')) | Should -BeTrue
+        }
+
+        It 'Defaults module frames to not-in-app' {
+            $sut = [StackTraceProcessor]::new([Sentry.SentryOptions]::new())
+            $sut.ResolveInApp((New-Frame 'Pester')) | Should -BeFalse
+        }
+
+        It 'Honors InAppInclude for module frames' {
+            $options = [Sentry.SentryOptions]::new()
+            $options.AddInAppInclude('MyApp')
+            $sut = [StackTraceProcessor]::new($options)
+            $sut.ResolveInApp((New-Frame 'MyApp')) | Should -BeTrue
+            $sut.ResolveInApp((New-Frame 'Pester')) | Should -BeFalse
+        }
+
+        It 'Honors InAppExclude for module frames' {
+            $options = [Sentry.SentryOptions]::new()
+            $options.AddInAppExclude('Pester')
+            $sut = [StackTraceProcessor]::new($options)
+            $sut.ResolveInApp((New-Frame 'Pester')) | Should -BeFalse
+            $sut.ResolveInApp((New-Frame 'MyApp')) | Should -BeFalse
+        }
+
+        It 'Matches prefix on dotted module names' {
+            $options = [Sentry.SentryOptions]::new()
+            $options.AddInAppInclude('MyApp')
+            $sut = [StackTraceProcessor]::new($options)
+            $sut.ResolveInApp((New-Frame 'MyApp.Submodule')) | Should -BeTrue
+            $sut.ResolveInApp((New-Frame 'MyAppOther')) | Should -BeFalse
+        }
+
+        It 'Honors regex include patterns' {
+            $options = [Sentry.SentryOptions]::new()
+            $options.AddInAppIncludeRegex('^My.*App$')
+            $sut = [StackTraceProcessor]::new($options)
+            $sut.ResolveInApp((New-Frame 'MyAwesomeApp')) | Should -BeTrue
+            $sut.ResolveInApp((New-Frame 'OtherApp')) | Should -BeFalse
+        }
+
+        It 'InAppExclude wins over InAppInclude' {
+            $options = [Sentry.SentryOptions]::new()
+            $options.AddInAppInclude('Foo')
+            $options.AddInAppExclude('Foo')
+            $sut = [StackTraceProcessor]::new($options)
+            $sut.ResolveInApp((New-Frame 'Foo')) | Should -BeFalse
+        }
+    }
 }

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -102,5 +102,17 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
             $sut = [StackTraceProcessor]::new($options)
             $sut.ResolveInApp((MakeFrame 'Foo')) | Should -BeFalse
         }
+
+        It 'MatchesAny operates on plain records without reflection' {
+            # The hot path consumes normalized { String; Regex } records (produced once in the ctor),
+            # so it must not depend on Sentry.StringOrRegex internals.
+            $stringPattern = [PSCustomObject]@{ String = 'MyApp'; Regex = $null }
+            $regexPattern = [PSCustomObject]@{ String = $null; Regex = [regex]'^Other.*' }
+            [StackTraceProcessor]::MatchesAny(@($stringPattern), 'MyApp.Sub') | Should -BeTrue
+            [StackTraceProcessor]::MatchesAny(@($stringPattern), 'Unrelated') | Should -BeFalse
+            [StackTraceProcessor]::MatchesAny(@($regexPattern), 'OtherThing') | Should -BeTrue
+            [StackTraceProcessor]::MatchesAny(@(), 'MyApp') | Should -BeFalse
+            [StackTraceProcessor]::MatchesAny($null, 'MyApp') | Should -BeFalse
+        }
     }
 }

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -60,11 +60,15 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
         }
 
         It 'Honors InAppExclude for module frames' {
+            # Module frames already default to not-in-app, so an exclude can only be *observed* when it
+            # overrides an include. Include both modules, exclude one, and verify only the other stays in-app.
             $options = [Sentry.SentryOptions]::new()
-            $options.AddInAppExclude('Pester')
+            $options.AddInAppInclude('Included')
+            $options.AddInAppInclude('Excluded')
+            $options.AddInAppExclude('Excluded')
             $sut = [StackTraceProcessor]::new($options)
-            $sut.ResolveInApp((MakeFrame 'Pester')) | Should -BeFalse
-            $sut.ResolveInApp((MakeFrame 'MyApp')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'Excluded')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'Included')) | Should -BeTrue
         }
 
         It 'Matches prefix on dotted module names' {

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -102,17 +102,5 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
             $sut = [StackTraceProcessor]::new($options)
             $sut.ResolveInApp((MakeFrame 'Foo')) | Should -BeFalse
         }
-
-        It 'MatchesAny operates on plain records without reflection' {
-            # The hot path consumes normalized { String; Regex } records (produced once in the ctor),
-            # so it must not depend on Sentry.StringOrRegex internals.
-            $stringPattern = [PSCustomObject]@{ String = 'MyApp'; Regex = $null }
-            $regexPattern = [PSCustomObject]@{ String = $null; Regex = [regex]'^Other.*' }
-            [StackTraceProcessor]::MatchesAny(@($stringPattern), 'MyApp.Sub') | Should -BeTrue
-            [StackTraceProcessor]::MatchesAny(@($stringPattern), 'Unrelated') | Should -BeFalse
-            [StackTraceProcessor]::MatchesAny(@($regexPattern), 'OtherThing') | Should -BeTrue
-            [StackTraceProcessor]::MatchesAny(@(), 'MyApp') | Should -BeFalse
-            [StackTraceProcessor]::MatchesAny($null, 'MyApp') | Should -BeFalse
-        }
     }
 }

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -33,7 +33,7 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
 
     Context 'ResolveInApp' {
         BeforeAll {
-            function New-Frame([string] $module) {
+            function MakeFrame([string] $module) {
                 $f = [Sentry.SentryStackFrame]::new()
                 $f.Module = $module
                 $f
@@ -42,45 +42,45 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
 
         It 'Defaults user-script frames (no module) to in-app' {
             $sut = [StackTraceProcessor]::new([Sentry.SentryOptions]::new())
-            $sut.ResolveInApp((New-Frame $null)) | Should -BeTrue
-            $sut.ResolveInApp((New-Frame '')) | Should -BeTrue
+            $sut.ResolveInApp((MakeFrame $null)) | Should -BeTrue
+            $sut.ResolveInApp((MakeFrame '')) | Should -BeTrue
         }
 
         It 'Defaults module frames to not-in-app' {
             $sut = [StackTraceProcessor]::new([Sentry.SentryOptions]::new())
-            $sut.ResolveInApp((New-Frame 'Pester')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'Pester')) | Should -BeFalse
         }
 
         It 'Honors InAppInclude for module frames' {
             $options = [Sentry.SentryOptions]::new()
             $options.AddInAppInclude('MyApp')
             $sut = [StackTraceProcessor]::new($options)
-            $sut.ResolveInApp((New-Frame 'MyApp')) | Should -BeTrue
-            $sut.ResolveInApp((New-Frame 'Pester')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'MyApp')) | Should -BeTrue
+            $sut.ResolveInApp((MakeFrame 'Pester')) | Should -BeFalse
         }
 
         It 'Honors InAppExclude for module frames' {
             $options = [Sentry.SentryOptions]::new()
             $options.AddInAppExclude('Pester')
             $sut = [StackTraceProcessor]::new($options)
-            $sut.ResolveInApp((New-Frame 'Pester')) | Should -BeFalse
-            $sut.ResolveInApp((New-Frame 'MyApp')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'Pester')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'MyApp')) | Should -BeFalse
         }
 
         It 'Matches prefix on dotted module names' {
             $options = [Sentry.SentryOptions]::new()
             $options.AddInAppInclude('MyApp')
             $sut = [StackTraceProcessor]::new($options)
-            $sut.ResolveInApp((New-Frame 'MyApp.Submodule')) | Should -BeTrue
-            $sut.ResolveInApp((New-Frame 'MyAppOther')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'MyApp.Submodule')) | Should -BeTrue
+            $sut.ResolveInApp((MakeFrame 'MyAppOther')) | Should -BeFalse
         }
 
         It 'Honors regex include patterns' {
             $options = [Sentry.SentryOptions]::new()
             $options.AddInAppIncludeRegex('^My.*App$')
             $sut = [StackTraceProcessor]::new($options)
-            $sut.ResolveInApp((New-Frame 'MyAwesomeApp')) | Should -BeTrue
-            $sut.ResolveInApp((New-Frame 'OtherApp')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'MyAwesomeApp')) | Should -BeTrue
+            $sut.ResolveInApp((MakeFrame 'OtherApp')) | Should -BeFalse
         }
 
         It 'InAppExclude wins over InAppInclude' {
@@ -88,7 +88,7 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
             $options.AddInAppInclude('Foo')
             $options.AddInAppExclude('Foo')
             $sut = [StackTraceProcessor]::new($options)
-            $sut.ResolveInApp((New-Frame 'Foo')) | Should -BeFalse
+            $sut.ResolveInApp((MakeFrame 'Foo')) | Should -BeFalse
         }
     }
 }

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -102,5 +102,14 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
             $sut = [StackTraceProcessor]::new($options)
             $sut.ResolveInApp((MakeFrame 'Foo')) | Should -BeFalse
         }
+
+        It 'Sentry.StringOrRegex still exposes the private fields we reflect on' {
+            # ResolveInApp reaches into the internal _string / _regex fields of Sentry.StringOrRegex.
+            # If a sentry-dotnet bump renames these, this fails so we catch it at upgrade time rather
+            # than silently no-op-ing InAppInclude/InAppExclude in production.
+            $flags = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Instance
+            [Sentry.StringOrRegex].GetField('_string', $flags) | Should -Not -BeNullOrEmpty
+            [Sentry.StringOrRegex].GetField('_regex', $flags) | Should -Not -BeNullOrEmpty
+        }
     }
 }

--- a/tests/stacktrace-processor.tests.ps1
+++ b/tests/stacktrace-processor.tests.ps1
@@ -79,6 +79,14 @@ at <ScriptBlock>, : line 3' -split "[`r`n]+"
             $sut.ResolveInApp((MakeFrame 'MyAppOther')) | Should -BeFalse
         }
 
+        It 'Matches case-insensitively for both exact and dotted-prefix' {
+            $options = [Sentry.SentryOptions]::new()
+            $options.AddInAppInclude('myapp')
+            $sut = [StackTraceProcessor]::new($options)
+            $sut.ResolveInApp((MakeFrame 'MyApp')) | Should -BeTrue
+            $sut.ResolveInApp((MakeFrame 'MyApp.Submodule')) | Should -BeTrue
+        }
+
         It 'Honors regex include patterns' {
             $options = [Sentry.SentryOptions]::new()
             $options.AddInAppIncludeRegex('^My.*App$')


### PR DESCRIPTION
## Summary

Make the PowerShell SDK respect the standard `InAppInclude` / `InAppExclude` options when classifying stack frames.

Each PS stack frame is stamped with a `Module` field by `StackTraceProcessor` (the directory name under a `$env:PSModulePath` entry — e.g. `…/Modules/Sentry/0.4.0/private/Foo.ps1` → `Module = "Sentry"`). 

This PR checks that module name against the includes/excludes configured on the sentry options (see [default excludes here](https://github.com/getsentry/sentry-dotnet/blob/9587f9991fef0e66eb810c47200cfe030320927c/src/Sentry/SentryOptions.cs#L1954-L1999)):

1. If `Module` matches any **InAppExclude** entry → `InApp = false`
2. Else if `Module` matches any **InAppInclude** entry → `InApp = true`
3. Else fall back to the existing PS default: empty `Module` (user script) → in-app; non-empty (module) → not in-app

This is slightly different to how sentry-dotnet does it because in PS, where code is in a module it's most likely third-party (per [the solution prior to this PR](https://github.com/getsentry/sentry-powershell/blob/7c23d54e3c19f482c8d23006315740728cc4f73b/modules/Sentry/private/StackTraceProcessor.ps1#L140)). 

Those rules for includes/excludes also makes it a little bit tricky to test InAppExcludes work properly - which is why we have [this slightly convoluted test](https://github.com/getsentry/sentry-powershell/blob/f468429296ab01c9896c7d6bc09d1c6e576bda82/tests/stacktrace-processor.tests.ps1#L62-L72).

## Implementation notes

[SentryOptions.InAppInclude](https://github.com/getsentry/sentry-dotnet/blob/9587f9991fef0e66eb810c47200cfe030320927c/src/Sentry/SentryOptions.cs#L311) / [InAppExclude](https://github.com/getsentry/sentry-dotnet/blob/9587f9991fef0e66eb810c47200cfe030320927c/src/Sentry/SentryOptions.cs#L298) are both internal — reached via reflection at construction time. Both lists are snapshotted on the processor instance, so the reflection cost is paid once per `Out-Sentry` invocation, not per frame.

Normally both of those properties get used implicitly when [SentryStackFrame.ConfigureAppFrame](https://github.com/getsentry/sentry-dotnet/blob/9beef00b325bd79c2cf43829f069142461aec113/src/Sentry/SentryStackFrame.cs#L193) is called but the way InApp gets resolved by that method wouldn't be quite what we want to happen in PS.

Closes #127